### PR TITLE
Remove properties from user profile (+ fix request and tests to changes)

### DIFF
--- a/src/fetcher/graphql/requests/user/profile.ts
+++ b/src/fetcher/graphql/requests/user/profile.ts
@@ -3,12 +3,7 @@ import { Expose, Transform, plainToClass } from 'class-transformer';
 import { GraphQLRequest, GraphQLFragment, GraphQLObjectField } from '../../utils';
 import { GITHUB_GRAPHQL_OBJECT_NAMES } from '../../common/fragments';
 import { ParseError } from '../../../../lib/errors';
-import {
-    UserProfile,
-    OrganizationProfileMinified,
-    RepositoryProfileMinified,
-    GistProfileMinified
-} from '../../../../models';
+import { UserProfile } from '../../../../models';
 
 class UserProfileParseModel implements UserProfile {
     @Expose()
@@ -38,12 +33,6 @@ class UserProfileParseModel implements UserProfile {
     @Expose()
     @Transform((obj): number => _.get(obj, 'count'))
     followersCount!: number;
-
-    organizationMemberships!: OrganizationProfileMinified[]; // To be set later with data from another request
-
-    publicRepositoryOwnerships!: RepositoryProfileMinified[]; // To be set later with data from another request
-
-    publicGists!: GistProfileMinified[]; // To be set later with data from another request
 }
 
 const fragment = new GraphQLFragment('UserProfile', GITHUB_GRAPHQL_OBJECT_NAMES.User, [

--- a/src/fetcher/routes/user.ts
+++ b/src/fetcher/routes/user.ts
@@ -26,24 +26,6 @@ export default class UserRoute extends Routefetcher {
 
         if (!fetchedProfile) return null;
 
-        // Fetch info about organizations user is member of, and add result to profile
-        const organizationMemberships = await this.getOrganizationMemberships(username);
-        if (organizationMemberships) {
-            fetchedProfile.organizationMemberships = organizationMemberships;
-        }
-
-        // Fetch info about public repositories that the user owns, and add result to profile
-        const publicRepositoryOwnerships = await this.getPublicRepositoryOwnerships(username);
-        if (publicRepositoryOwnerships) {
-            fetchedProfile.publicRepositoryOwnerships = publicRepositoryOwnerships;
-        }
-
-        // Fetch info about public gists that the user created, and add result to profile
-        const publicGists = await this.getPublicGists(username);
-        if (publicGists) {
-            fetchedProfile.publicGists = publicGists;
-        }
-
         return fetchedProfile;
     }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -40,18 +40,6 @@ export interface UserProfile {
      * Number of users following this profile
      */
     followersCount: number;
-    /**
-     * Organizations that the user is member of
-     */
-    organizationMemberships: OrganizationProfileMinified[];
-    /**
-     * The user's own public repositories
-     */
-    publicRepositoryOwnerships: RepositoryProfileMinified[];
-    /**
-     * The user's own public gists
-     */
-    publicGists: GistProfileMinified[];
 }
 
 /**

--- a/tests/integration/lib/model-validation.ts
+++ b/tests/integration/lib/model-validation.ts
@@ -186,15 +186,6 @@ function validateUserProfile(profile: UserProfile | null): void {
     _.forEach(keys<UserProfile>(), (propKey): void => {
         expect(_.get(profile, propKey)).toBeDefined();
     });
-
-    // Verify all properties set on 'organizationMemberships' property
-    validateOrganizationProfileMinified(profile.organizationMemberships);
-
-    // Verify all properties set on 'publicRepositoryOwnerships' property
-    validateRepositoryProfileMinified(profile.publicRepositoryOwnerships);
-
-    // Verify all properties set on 'publicGists' property
-    validateMinGistProfile(profile.publicGists);
 }
 
 export default {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { APIFetcher } from '../../src/main';
 import randomData from './lib/random-data';
 import modelValidation from './lib/model-validation';
-import { UserProfile } from '../../src/models';
+import { UserProfile, OrganizationProfileMinified } from '../../src/models';
 import { Month } from '../../src/lib/date-utils';
 
 jest.setTimeout(60000); // 60 seconds timeout for all tests and before/after hooks. Tests fails with error if timeout is exceeded
@@ -26,10 +26,14 @@ describe('APIFetcher', (): void => {
             async (): Promise<void> => {
                 // Find eligible user profile with at least one organization membership
                 let result: UserProfile | null = null;
+                let randomUserOrganizationMemberships: OrganizationProfileMinified[] = [];
 
-                while (!result || _.isEmpty(result.organizationMemberships)) {
+                while (!result || _.isEmpty(randomUserOrganizationMemberships)) {
                     const randomUsername = await randomData.getUsernameOfRandomUser();
                     result = await fetcher.user.getProfile(randomUsername);
+                    randomUserOrganizationMemberships = (await fetcher.user.getOrganizationMemberships(
+                        randomUsername
+                    ))!;
                 }
 
                 userProfile = result;


### PR DESCRIPTION
**Changes**:
Removed properties ```organizationMemberships```, ```publicRepositoryOwnerships``` and ```publicGists``` from ```UserProfile``` model.

**Reason**:
The model was getting "heavy" besides the basic properties like ```displayName```, ```followersCount```, ```avatarUrl``` etc. It is my intention to make the model "lightweight" and relatively quick to fetch. The data found in the removed properties can still be retrieved with the following requests: ```getOrganizationMemberships```, ```getPublicRepositoryOwnerships``` and ```getPublicGists```.