### PR TITLE
Rename 'gistName' to 'gistId'; NOT_FOUND error for request for a non-existing gist created by an existing user

### DIFF
--- a/src/fetcher/graphql/common/fragments.ts
+++ b/src/fetcher/graphql/common/fragments.ts
@@ -43,7 +43,7 @@ export default {
     ]),
     minifiedGist: new GraphQLFragment('minGistProfile', GITHUB_GRAPHQL_OBJECT_NAMES.Gist, [
         new GraphQLObjectField('id', 'gitHubId'),
-        new GraphQLObjectField('name'),
+        new GraphQLObjectField('name', 'gistId'),
         new GraphQLObjectField('owner', 'ownerUsername', [new GraphQLObjectField('login', 'username')]),
         new GraphQLObjectField('url', 'publicUrl')
     ])

--- a/src/fetcher/graphql/common/parse-models.ts
+++ b/src/fetcher/graphql/common/parse-models.ts
@@ -68,7 +68,7 @@ export class MinGistProfileParseModel implements GistProfileMinified {
     gitHubId!: string;
 
     @Expose()
-    name!: string;
+    gistId!: string;
 
     @Expose()
     @Transform((obj): string => _.get(obj, 'username'))

--- a/src/fetcher/graphql/requests/gist/profile.test.ts
+++ b/src/fetcher/graphql/requests/gist/profile.test.ts
@@ -1,0 +1,31 @@
+import GetGistProfileRequest from './profile';
+import { GraphQLRequest } from '../../utils';
+import { GistProfile } from '../../../../models';
+import { RequestError, ResponseErrorType } from '../../../../lib/errors';
+
+describe('GetGistProfileRequest', (): void => {
+    let request: GraphQLRequest<GistProfile>;
+
+    beforeEach((): void => {
+        request = new GetGistProfileRequest('dummy-user', 'dummy-gist-id');
+    });
+
+    describe('parseResponse', (): void => {
+        it('should throw RequestError of NOT_FOUND type when returned data is null', (): void => {
+            const response = {
+                user: {
+                    gist: null
+                }
+            };
+
+            try {
+                request.parseResponse(response);
+                throw new Error(`Test didn't throw error`);
+            } catch (error) {
+                const requestError = error as RequestError;
+
+                expect(requestError.type).toBe(ResponseErrorType.NOT_FOUND);
+            }
+        });
+    });
+});

--- a/src/fetcher/routes/gist.ts
+++ b/src/fetcher/routes/gist.ts
@@ -10,9 +10,9 @@ export default class GistRoute extends Routefetcher {
      * Example: getGist('staltz', '868e7e9bc2a7b8c1f754')
      *
      * @param ownerUsername The GitHub username of the owner
-     * @param gistName Name of the gist
+     * @param gistId The gist's id (same as the name of the gist)
      */
-    async getProfile(ownerUsername: string, gistName: string): Promise<GistProfile | null> {
-        return await this.fetcher.fetch<GistProfile>(new GistRequests.Profile(ownerUsername, gistName));
+    async getProfile(ownerUsername: string, gistId: string): Promise<GistProfile | null> {
+        return await this.fetcher.fetch<GistProfile>(new GistRequests.Profile(ownerUsername, gistId));
     }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -289,9 +289,9 @@ export interface GistProfileMinified {
      */
     gitHubId: string;
     /**
-     * Name of gist
+     * The gist's id (same as the name of the gist)
      */
-    name: string;
+    gistId: string;
     /**
      * GitHub username of owner of gist
      */

--- a/tests/integration/lib/random-data.ts
+++ b/tests/integration/lib/random-data.ts
@@ -158,16 +158,16 @@ async function getRandomPRContributionTime(username: string): Promise<[number, M
 }
 
 /**
- * Fetches random gist, and returns username of owner and name of the gist as tuple
+ * Fetches random gist, and returns username of owner and id of the gist as tuple
  */
 async function getRandomGist(): Promise<[string, string]> {
     const randomGists = await fetchGitHubAPI('gists/public');
     const randomGist = _.sample(randomGists) as object;
 
     const ownerUsername = _.get(randomGist, 'owner.login') as string;
-    const gistName = _.get(randomGist, 'id') as string;
+    const gistId = _.get(randomGist, 'id') as string;
 
-    return [ownerUsername, gistName];
+    return [ownerUsername, gistId];
 }
 
 /**

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import _ from 'lodash';
+import uuid = require('uuid');
 import { APIFetcher } from '../../src/main';
 import randomData from './lib/random-data';
 import modelValidation from './lib/model-validation';
@@ -431,17 +432,28 @@ describe('APIFetcher', (): void => {
 
     describe('gist', (): void => {
         describe('getProfile', (): void => {
+            let [randomGistOwnerUsername, randomGistId]: [string, string] = ['', ''];
+
+            beforeAll(
+                async (): Promise<void> => {
+                    [randomGistOwnerUsername, randomGistId] = await randomData.getRandomGist();
+                }
+            );
+
             it('should return model with all properties set', async (): Promise<void> => {
-                const [randomOwnerUsername, randomGistName] = await randomData.getRandomGist();
-                const result = await fetcher.gist.getProfile(randomOwnerUsername, randomGistName);
+                const result = await fetcher.gist.getProfile(randomGistOwnerUsername, randomGistId);
 
                 modelValidation.validateGistProfile(result);
             });
 
-            it('should return null for non-existing gist', async (): Promise<void> => {
-                const [nonExistingOwnerUsername, nonExistingGistName] = await randomData.getNonExistingGist();
+            it('should return null for non-existing gist created by non-existing user', async (): Promise<void> => {
+                const [nonExistingOwnerUsername, nonExistingGistId] = await randomData.getNonExistingGist();
 
-                expect(await fetcher.gist.getProfile(nonExistingOwnerUsername, nonExistingGistName)).toBeNull();
+                expect(await fetcher.gist.getProfile(nonExistingOwnerUsername, nonExistingGistId)).toBeNull();
+            });
+
+            it('should return null for non-existing gist created by existing user', async (): Promise<void> => {
+                expect(await fetcher.gist.getProfile(randomGistId, uuid())).toBeNull();
             });
         });
     });


### PR DESCRIPTION
**Relates to:**
- Solves #18 

**Code changes:**
- Rename ```name``` property to ```gistId``` in ```GistProfile``` model.
- Throws ```RequestError``` of ```NOT_FOUND``` type when a request for a non-existing gist created by an existing user is sent.
- Unit test and integration test for changes.